### PR TITLE
Drop zero-variance columns from PCA

### DIFF
--- a/R/configure_report.r
+++ b/R/configure_report.r
@@ -42,7 +42,7 @@
 configure_report <- function(
   add_introduce = TRUE,
   add_plot_intro = TRUE,
-  add_plot_str = TRUE,
+  add_plot_str = FALSE, # turned off for now
   add_plot_missing = TRUE,
   add_plot_histogram = TRUE,
   add_plot_density = FALSE,

--- a/R/plot_prcomp.r
+++ b/R/plot_prcomp.r
@@ -39,7 +39,7 @@ plot_prcomp <- function(data, variance_cap = 0.8, maxcat = 50L, prcomp_args = li
   ## Remove columns with zero variance
   cond <- sapply(dt, function(x) length(unique(x))==1)
   cond <- names(cond)[cond]
-  setDT(dt)[, c(cond) := NULL]
+  dt[, c(cond) := NULL]
   prcomp_args_list <- list("x" = dt, "retx" = FALSE)
   ## Analyze principal components
   pca <- tryCatch(

--- a/R/plot_prcomp.r
+++ b/R/plot_prcomp.r
@@ -38,8 +38,7 @@ plot_prcomp <- function(data, variance_cap = 0.8, maxcat = 50L, prcomp_args = li
   dt <- suppressWarnings(split_columns(dummify(data, maxcat = maxcat))$continuous)
   ## Remove columns with zero variance
   cond <- sapply(dt, function(x) length(unique(x))==1)
-  cond <- names(cond)[cond]
-  setDT(dt)[, c(cond) := NULL]
+  dt=dt[,names(cond)[cond]]
   prcomp_args_list <- list("x" = dt, "retx" = FALSE)
   ## Analyze principal components
   pca <- tryCatch(

--- a/R/plot_prcomp.r
+++ b/R/plot_prcomp.r
@@ -36,6 +36,10 @@ plot_prcomp <- function(data, variance_cap = 0.8, maxcat = 50L, prcomp_args = li
   if (!is.data.table(data)) data <- data.table(data)
   ## Dummify data
   dt <- suppressWarnings(split_columns(dummify(data, maxcat = maxcat))$continuous)
+  ## Remove columns with zero variance
+  cond <- sapply(dt, function(x) length(unique(x))==1)
+  cond <- names(cond)[cond]
+  dt[, c(cond) := NULL]
   prcomp_args_list <- list("x" = dt, "retx" = FALSE)
   ## Analyze principal components
   pca <- tryCatch(

--- a/R/plot_prcomp.r
+++ b/R/plot_prcomp.r
@@ -38,7 +38,8 @@ plot_prcomp <- function(data, variance_cap = 0.8, maxcat = 50L, prcomp_args = li
   dt <- suppressWarnings(split_columns(dummify(data, maxcat = maxcat))$continuous)
   ## Remove columns with zero variance
   cond <- sapply(dt, function(x) length(unique(x))==1)
-  dt=dt[,names(cond)[cond]]
+  cond <- names(cond)[cond]
+  setDT(dt)[, c(cond) := NULL]
   prcomp_args_list <- list("x" = dt, "retx" = FALSE)
   ## Analyze principal components
   pca <- tryCatch(

--- a/R/plot_prcomp.r
+++ b/R/plot_prcomp.r
@@ -39,7 +39,7 @@ plot_prcomp <- function(data, variance_cap = 0.8, maxcat = 50L, prcomp_args = li
   ## Remove columns with zero variance
   cond <- sapply(dt, function(x) length(unique(x))==1)
   cond <- names(cond)[cond]
-  dt[, c(cond) := NULL]
+  setDT(dt)[, c(cond) := NULL]
   prcomp_args_list <- list("x" = dt, "retx" = FALSE)
   ## Analyze principal components
   pca <- tryCatch(

--- a/inst/rmd_template/report.rmd
+++ b/inst/rmd_template/report.rmd
@@ -35,7 +35,6 @@ opts_chunk$set(
 )
 ```
 
-<script src="d3.min.js"></script>
 
 ```{r introduce}
 if ("introduce" %in% names(report_config)) {
@@ -72,6 +71,13 @@ if ("plot_intro" %in% names(report_config)) {
 }
 ```
 
+
+```{r script_structure}
+if ("plot_str" %in% names(report_config)) {
+    knitr::raw_html('<script src="d3.min.js"></script>')
+}
+```
+
 ```{r data_structure}
 if ("plot_str" %in% names(report_config)) {
   str_object <- do.call(plot_str, c(list("data" = data, "max_level" = report_config[["plot_str"]][["max_level"]], "print_network" = FALSE)))
@@ -100,7 +106,7 @@ if (any(c("plot_bar", "plot_histogram", "plot_density", "plot_qq") %in% names(re
 ```
 
 ```{r plot_histogram}
-if ("plot_histogram" %in% names(report_config)) {
+if ("plot_histogram" %in% names(report_config)) {   
   if (intro[["continuous_columns"]] > 0) {
     cat("#### Histogram", fill = TRUE)
     do_call("plot_histogram")


### PR DESCRIPTION
I was encountering errors around d3 (#116 ) and the PCA erroring on the nycflight13 data which I tend to use as a more realistic example in my classes.

## Makes d3 script inclusion dynamic 
This will enable a workaround for the current pandoc conversion issue by excluding the script from the Rmd if the d3 plot is set to not render. This doesn't fix the full issue but offers a workaround.

```
create_report(flights,
  config = configure_report(
    add_plot_str = FALSE
  ))
```

## Drop zero-var columns from PCA
DataExplorer was producing a hard to diagnose error when there were columns with zero variance (e.g. nycflights13::flights$year). This change drops any zero variance columns from being included in the PCA analysis.