### PR TITLE
Add YAML option to allow html elements when choosing PDF report

### DIFF
--- a/inst/rmd_template/report.rmd
+++ b/inst/rmd_template/report.rmd
@@ -5,6 +5,7 @@ params:
   response: response
   set_title: report_title
 title: "`r params$set_title`"
+always_allow_html: true
 ---
 
 ```{r global_options, include=FALSE}


### PR DESCRIPTION
Producing a PDF output with `create_report()` causes an error because there are several `networkD3` functions that are called in the `rmd_template`, but they can only be produced in an HTML output. For example:
```
create_report(iris, output_file = "report.pdf", output_format = "pdf_document") 

... Compilation message...


Erreur : Functions that produce HTML output found in document targeting latex output.
Please change the output type of this document to HTML. Alternatively, you can allow
HTML output in non-HTML formats by adding this option to the YAML front-matter of
your rmarkdown file:

  always_allow_html: true

Note however that the HTML output will not be visible in non-HTML formats.
```
Therefore, I added the line specified in the error message (`always_allow_html: true`) in the YAML. An alternative solution would be to wrap the lines concerned in `if (knitr::is_html_output())`.